### PR TITLE
Add feature to set atime and mtime of files

### DIFF
--- a/matrix-archive.py
+++ b/matrix-archive.py
@@ -97,6 +97,8 @@ async def write_event(
                     event.source["content"]["file"]["iv"],
                 )
             )
+            # Set atime and mtime of file to event timestamp
+            os.utime(filename, ns=((event.server_timestamp * 1000000,) * 2))
         await output_file.write(serialize_event(dict(type="media", src=filename,)))
     elif isinstance(event, RedactedEvent):
         await output_file.write(serialize_event(dict(type="redacted",)))


### PR DESCRIPTION
I think this should fix #1 by using [`os.utime`](https://docs.python.org/3/library/os.html#os.utime). I have tested it and it works for me. Let me know if there's anything else to consider. :+1: 