### PR TITLE
Add workaround for rooms where a user has left

### DIFF
--- a/matrix-archive.py
+++ b/matrix-archive.py
@@ -70,12 +70,16 @@ async def write_event(
     client: AsyncClient, room: MatrixRoom, output_file: TextIO, event: RoomMessage
 ) -> None:
     media_dir = mkdir(f"{OUTPUT_DIR}/{room.display_name}_{room.room_id}_media")
+    sender_name = f"<{event.sender}>"
+    if event.sender in room.users:
+        # If user is still present in room, include current nickname
+        sender_name = f"{room.users[event.sender].display_name} {sender_name}"
     serialize_event = lambda event_payload: yaml.dump(
         [
             {
                 **dict(
                     sender_id=event.sender,
-                    sender_name=room.users[event.sender].display_name,
+                    sender_name=sender_name,
                     timestamp=event.server_timestamp,
                 ),
                 **event_payload,


### PR DESCRIPTION
I think this should be a quick workaround for #7 to prevent the script from crashing and aborting the whole backup. It doesn't completely fix the issue though: still, only the current display name is being used.