### PR TITLE
Add option to skip downloading media

### DIFF
--- a/matrix-archive.py
+++ b/matrix-archive.py
@@ -18,6 +18,7 @@ from functools import partial
 from typing import Union, TextIO
 from urllib.parse import urlparse
 import aiofiles
+import argparse
 import asyncio
 import getpass
 import os
@@ -34,9 +35,6 @@ def mkdir(path):
     except FileExistsError:
         pass
     return path
-
-
-OUTPUT_DIR = mkdir(sys.argv[1] if 1 < len(sys.argv) else ".")
 
 
 async def create_client() -> AsyncClient:
@@ -189,4 +187,9 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output_dir", default=".", nargs="?",
+        help="directory to store output (optional; defaults to current directory)")
+    args = parser.parse_args()
+    OUTPUT_DIR = args.output_dir
     asyncio.get_event_loop().run_until_complete(main())


### PR DESCRIPTION
Adds a `--no-media` command line option to skip downloading media.

This is useful for when the user is only interested in message content in rooms with lots of images etc. This implementation also makes it so that media messages won't be listed in the YAML file at all when --no-media is used, which may or may not be desirable. Let me know if you have any ideas for a better way to do this.

I figured it's probably best to use argparse for command line arguments, but happy to change this if requested.