### PR TITLE
Remove quotes in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-"matrix-nio[e2e]"
+matrix-nio[e2e]
 pyyaml


### PR DESCRIPTION
Quotes are only needed in a shell, not in requirements.txt, and
instead cause `pip install -r requirements.txt` to fail.