### PR TITLE
Leave file names as relative in yaml files

### DIFF
--- a/matrix-archive.py
+++ b/matrix-archive.py
@@ -115,7 +115,7 @@ async def write_event(
                 await f.write(media_data)
             # Set atime and mtime of file to event timestamp
             os.utime(filename, ns=((event.server_timestamp * 1000000,) * 2))
-        await output_file.write(serialize_event(dict(type="media", src=filename,)))
+        await output_file.write(serialize_event(dict(type="media", src="." + filename[len(OUTPUT_DIR):],)))
     elif isinstance(event, RedactedEvent):
         await output_file.write(serialize_event(dict(type="redacted",)))
 


### PR DESCRIPTION
If `--output` is given, that relative path is added inside the yaml files even though themselves are already there; that's misleading when working with the files, and worse yet has the effect that different runs on different locations produce different results.

For example, if `--output outdir` was given, the file in `outdir/foo_!xxx:example.com.yaml` would itself contain a line `src: outdir/foo_!xxx:example.com_media/file.jpg` rather than the path starting where the file is.

This patch stores the file name in the yaml as `./room_!..._media/filename` as it is without `--output`, thus creating consistency for the consumer of the yaml file. (The leading dot has the side effect that users that expect a URI relative reference are not confused.)