### PR TITLE
Fix downloading media with newer versions of matrix-nio: pass arguments by name to AsyncClient.download.

### DIFF
--- a/matrix-archive.py
+++ b/matrix-archive.py
@@ -272,7 +272,7 @@ async def save_avatars(client: AsyncClient, room: MatrixRoom) -> None:
 
 async def download_mxc(client: AsyncClient, url: str):
     mxc = urlparse(url)
-    response = await client.download(mxc.netloc, mxc.path.strip("/"))
+    response = await client.download(server_name=mxc.netloc, media_id=mxc.path.strip("/"))
     if hasattr(response, "body"):
         return response.body
     else:


### PR DESCRIPTION
The signature of AsyncClient.download has changed between matrix-nio versions. To be compatible with both older and recent versions we need to pass `server_name` and `media_id` by name.

*Credits*: Thanks [@mindslight:matrix.org](https://matrix.to/#/@mindslight:matrix.org) for finding the bug.

*Note*: a recent matrix-nio will complain that `server_name` and `media_id` arguments are being deprecated. A more long-term solution would be to require a recent version of matrix-nio and passing `url` unchanged to the `AsyncClient.download` function (which is the new api).