### PR TITLE
Fix media download; require not-too-old matrix-nio.

### DIFF
--- a/matrix-archive.py
+++ b/matrix-archive.py
@@ -271,8 +271,7 @@ async def save_avatars(client: AsyncClient, room: MatrixRoom) -> None:
 
 
 async def download_mxc(client: AsyncClient, url: str):
-    mxc = urlparse(url)
-    response = await client.download(mxc.netloc, mxc.path.strip("/"))
+    response = await client.download(url)
     if hasattr(response, "body"):
         return response.body
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-matrix-nio[e2e]
+matrix-nio[e2e] >= 0.20.0
 pyyaml


### PR DESCRIPTION
The signutare of AsyncClient.download in matrix-nio has changed since matrix-archive was written. This PR uses the new signature. It also adds a version boundary for matrix-nio in requirements.txt.

Credits: Thanks [@mindslight:matrix.org](https://matrix.to/#/@mindslight:matrix.org) for finding the bug.