### PR TITLE
Fix path traversal vulnerabilities

### DIFF
--- a/matrix-archive.py
+++ b/matrix-archive.py
@@ -335,7 +335,8 @@ async def save_avatars(client: AsyncClient, room: MatrixRoom) -> None:
     avatar_dir = mkdir(f"{OUTPUT_DIR}/{safe_room_name}_{room.room_id}_avatars")
     for user in room.users.values():
         if user.avatar_url:
-            async with aiofiles.open(f"{avatar_dir}/{user.user_id}", "wb") as f:
+            safe_user_id = sanitize_path_component(user.user_id, "unknown_user")
+            async with aiofiles.open(f"{avatar_dir}/{safe_user_id}", "wb") as f:
                 await f.write(await download_mxc(client, user.avatar_url))
 
 

--- a/matrix-archive.py
+++ b/matrix-archive.py
@@ -286,8 +286,9 @@ def choose_filename(filename):
 async def write_event(
     client: AsyncClient, room: MatrixRoom, output_file: TextIO, event: RoomMessage
 ) -> None:
+    safe_room_name = sanitize_path_component(room.display_name, room.room_id)
     if not ARGS.no_media:
-        media_dir = mkdir(f"{OUTPUT_DIR}/{room.display_name}_{room.room_id}_media")
+        media_dir = mkdir(f"{OUTPUT_DIR}/{safe_room_name}_{room.room_id}_media")
     sender_name = f"<{event.sender}>"
     if event.sender in room.users:
         # If user is still present in room, include current nickname
@@ -330,7 +331,8 @@ async def write_event(
 
 
 async def save_avatars(client: AsyncClient, room: MatrixRoom) -> None:
-    avatar_dir = mkdir(f"{OUTPUT_DIR}/{room.display_name}_{room.room_id}_avatars")
+    safe_room_name = sanitize_path_component(room.display_name, room.room_id)
+    avatar_dir = mkdir(f"{OUTPUT_DIR}/{safe_room_name}_{room.room_id}_avatars")
     for user in room.users.values():
         if user.avatar_url:
             async with aiofiles.open(f"{avatar_dir}/{user.user_id}", "wb") as f:
@@ -372,6 +374,7 @@ async def fetch_room_events(
 
 async def write_room_events(client, room):
     print(f"Fetching {room.room_id} room messages and writing to disk...")
+    safe_room_name = sanitize_path_component(room.display_name, room.room_id)
     sync_resp = await client.sync(
         full_state=True, sync_filter={"room": {"timeline": {"limit": 1}}}
     )
@@ -381,7 +384,7 @@ async def write_room_events(client, room):
     # as well.
     fetch_room_events_ = partial(fetch_room_events, client, start_token, room)
     async with aiofiles.open(
-        f"{OUTPUT_DIR}/{room.display_name}_{room.room_id}.json", "w"
+        f"{OUTPUT_DIR}/{safe_room_name}_{room.room_id}.json", "w"
     ) as f_json:
         for events in [
             reversed(await fetch_room_events_(MessageDirection.back)),
@@ -391,7 +394,7 @@ async def write_room_events(client, room):
             for event in events:
                 try:
                     if not ARGS.no_media:
-                        media_dir = mkdir(f"{OUTPUT_DIR}/{room.display_name}_{room.room_id}_media")
+                        media_dir = mkdir(f"{OUTPUT_DIR}/{safe_room_name}_{room.room_id}_media")
 
                     # add additional information to the message source
                     sender_name = f"<{event.sender}>"

--- a/matrix-archive.py
+++ b/matrix-archive.py
@@ -259,6 +259,21 @@ async def select_room(client: AsyncClient) -> MatrixRoom:
     return client.rooms[room_id]
 
 
+def sanitize_path_component(name: str, fallback: str = "unnamed") -> str:
+    """Sanitize a string for safe use as a file or directory name component.
+
+    Strips directory separators and traversal sequences to prevent
+    path traversal attacks from user-controlled input.
+    """
+    name = os.path.basename(name)
+    name = name.replace("\0", "")
+    name = name.replace("\\", "_")
+    name = name.replace("..", "_")
+    if not name or name.isspace():
+        name = fallback
+    return name
+
+
 def choose_filename(filename):
     start, ext = os.path.splitext(filename)
     for i in itertools.count(1):
@@ -294,7 +309,7 @@ async def write_event(
         await output_file.write(serialize_event(dict(type="text", body=event.body,)))
     elif isinstance(event, (RoomMessageMedia, RoomEncryptedMedia)):
         media_data = await download_mxc(client, event.url)
-        filename = choose_filename(f"{media_dir}/{event.body}")
+        filename = choose_filename(f"{media_dir}/{sanitize_path_component(event.body, 'media')}")
         async with aiofiles.open(filename, "wb") as f:
             try:
                 await f.write(
@@ -388,7 +403,7 @@ async def write_room_events(client, room):
                     # download media if necessary
                     if isinstance(event, (RoomMessageMedia, RoomEncryptedMedia)):
                         media_data = await download_mxc(client, event.url)
-                        filename = choose_filename(f"{media_dir}/{event.body}")
+                        filename = choose_filename(f"{media_dir}/{sanitize_path_component(event.body, 'media')}")
                         event.source["_file_path"] = filename
                         async with aiofiles.open(filename, "wb") as f_media:
                             try:


### PR DESCRIPTION
## Summary

- Fix three HIGH severity path traversal vulnerabilities where attacker-controlled strings (`event.body`, `room.display_name`, `user.user_id`) were used unsanitized in file/directory paths, allowing writes outside the output directory

## Security fixes

All three fixes share a new `sanitize_path_component()` helper that strips directory separators, null bytes, and `..` traversal sequences via `os.path.basename()`:

-  `Fix H1: sanitize event.body to prevent path traversal in media filenames`
-  `Fix H2: sanitize room.display_name to prevent path traversal in output paths`
-  `Fix H3: sanitize user.user_id to prevent path traversal in avatar filenames`

